### PR TITLE
Update .gitattributes to include addons folder in Asset Library exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
Adds export-ignore rules to [.gitattributes](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to ensure only the [addons](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) folder is included when users download the plugin from the Godot Asset Library.

Changes
Updated [.gitattributes](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with export-ignore patterns
All files excluded by default except [addons](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and its contents
Why
Currently users downloading from the Asset Library get the entire repository including samples, branding, and other development files. This change keeps those files in the repo for development/documentation purposes while excluding them from Asset Library downloads.

Resolves #1 